### PR TITLE
release gem group: Add missing faraday-retry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-group :release do
-  gem 'github_changelog_generator', '>= 1.16.1', require: false
+group :release, optional: true do
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
 end


### PR DESCRIPTION
GCG has an optional dependency to faraday-retry. When the gem is missing we get a warning.